### PR TITLE
Fixed canary bug and added clarity around merge options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.7 (November 20, 2022)
+
+BUG:
+  * Fixed issue where canary couldn't be destroyed after being created.
+  * Now we create the stage before it's destroyed.
+
+FEATURE:
+  * Added "Managed by Terraform" description to deployments.
+  * Append "Deployed on {timestamp}" to stage descriptions.
+
+CHORE:
+  * Improved notes for the `aws_api_gateway_deployment` resource.
+  * Updated README about `put_rest_api_mode` usage & known issues.
+
 ## 1.0.6 (November 1, 2022)
 
 CHORE:

--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -1,14 +1,14 @@
 ### Terraform Basic Example + Lambda (as authorizer)
 ```
 module "rest-api" {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",
@@ -45,14 +45,14 @@ inputs = {
 ### Terraform Example + Lambda (as authorizer) + Stage Canary + Method Settings
 ```
 module "rest-api" {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",
@@ -114,14 +114,14 @@ inputs = {
 ### Terraform Complete Example + Lambda (as authorizer) + Stage Canary + Method Settings + WAF
 ```
 module "rest-api" {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",
@@ -185,14 +185,14 @@ inputs = {
 ### Terraform Complete Example + Lambda (as authorizer) + Stage Canary + Method Settings + WAF + API Keys + Usage Plans
 ```
 module "rest-api" {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -1,10 +1,10 @@
 module "rest-api" {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${path.module}/openapi.yaml",

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -1,14 +1,14 @@
 ### Terragrunt Basic Example + Lambda (as authorizer)
 ```
 terraform {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 }
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",
@@ -45,14 +45,14 @@ inputs = {
 ### Terragrunt Example + Lambda (as authorizer) + Stage Canary + Method Settings
 ```
 terraform {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 }
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",
@@ -114,14 +114,14 @@ inputs = {
 ### Terragrunt Complete Example + Lambda (as authorizer) + Stage Canary + Method Settings + WAF
 ```
 terraform {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 }
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",
@@ -185,14 +185,14 @@ inputs = {
 ### Terragrunt Complete Example + Lambda (as authorizer) + Stage Canary + Method Settings + WAF + API Keys + Usage Plans
 ```
 terraform {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 }
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",

--- a/examples/terragrunt/terragrunt.hcl
+++ b/examples/terragrunt/terragrunt.hcl
@@ -33,14 +33,14 @@ dependency "execution_policy" {
 }
 
 terraform {
-  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.6"
+  source = "git::git@github.com:adamwshero/terraform-aws-api-gateway.git//.?ref=1.0.7"
 }
 
 inputs = {
   api_name          = "my-app-dev"
   description       = "Development API for the My App service."
   endpoint_type     = ["REGIONAL"]
-  put_rest_api_mode = "merge"
+  put_put_rest_api_mode = "merge"   // Toggle to `overwrite` only when renaming a resource path or removing a resource from the openapi definition.
 
   // API Definition & Vars
   openapi_definition = templatefile("${get_terragrunt_dir()}/openapi.yaml",


### PR DESCRIPTION
## 1.0.7 (November 20, 2022)

BUG:
  * Fixed issue where canary couldn't be destroyed after being created.
  * Now we create the stage before it's destroyed.

FEATURE:
  * Added "Managed by Terraform" description to deployments.
  * Append "Deployed on {timestamp}" to stage descriptions.

CHORE:
  * Improved notes for the `aws_api_gateway_deployment` resource.
  * Updated README about `put_rest_api_mode` usage & known issues.
