### PR TITLE
Handle deployment for private APIs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,6 @@ resource "aws_api_gateway_rest_api" "this" {
 
 resource "aws_api_gateway_deployment" "this" {
   count = length(var.stage_names) > 0 ? length(var.stage_names) : 0
-  ## Deployment for the PRIVATE APIs fails if the policy has not been attached
-  depends_on = [ aws_api_gateway_rest_api_policy.this ]
 
   rest_api_id = aws_api_gateway_rest_api.this.id
   description = "Managed by Terraform"
@@ -32,7 +30,8 @@ resource "aws_api_gateway_deployment" "this" {
     #       https://github.com/hashicorp/terraform-provider-aws/issues/162
 
     # redeployment = sha1(jsonencode([
-    #   aws_api_gateway_rest_api.this.body
+    #   aws_api_gateway_rest_api.this.body,
+    #   try(aws_api_gateway_rest_api_policy.this[0].id, null)
     #   ]
     # ))
 


### PR DESCRIPTION
## Description
creating API Gateway Deployment: operation error API Gateway: CreateDeployment, https response error StatusCode: 400, RequestID: 718397a6-8066-4d08-8d42-169056a78565, BadRequestException: Private REST API doesn't have a resource policy attached to it

## Motivation and Context
The change allows to create an API GW deployment resource. It will make sure that first the resource policy has been generated which is mandatory for the deployment

## How Has This Been Tested?
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->

